### PR TITLE
Prevent failure due to empty shell function

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -35,6 +35,7 @@ function get_cflogin() {
 #		CF_EMAIL="account@two.com"
 #		CF_KEY="k3ytw0"
 #	fi
+	:
 }
 
 function get_zone() {


### PR DESCRIPTION
If you're using a single Cloudflare account configured through `dehydrated/config` then you do not need to fill in the `get_cflogin` function. In that case Bash will return an error: `Syntax error: "}" unexpected`.

To make the script work by default, use `:` (true) operator to signify a no-op.